### PR TITLE
Wrapper for solve_triangular + tests

### DIFF
--- a/backslash/_backslash.py
+++ b/backslash/_backslash.py
@@ -1,15 +1,15 @@
 import numpy as np
 import scipy.linalg as sl
+from numpy.testing import assert_allclose
 
-KNOWN_FORMATS = {"general",}
 
-SOLVE_FUNCS = {"general": sl.solve,}
+SOLVE_FUNCS = {"general": sl.solve, "triangular": sl.solve_triangular} 
 
 
 def normalize_format(format):
     if format is None:
         format = "general"
-    if format not in KNOWN_FORMATS:
+    if format not in SOLVE_FUNCS.keys():
         raise ValueError(f"Unknown format {format}")
     return format
 
@@ -24,27 +24,33 @@ class Array(object):
     def format(self):
         return self._format
 
+    @property
+    def data(self):
+        return self._data
+
 
 def solve(a, b):
     """Solve a linear system a@x = b.
-    
+
     Parameters
     ----------
     a : Array
         Left-hand side
     b : numpy array, 1D
         Right-hand side
-        
+
     Returns
     -------
     numpy array : Solution of the linear system.
     """
+
     b = np.asarray(b)
     try:
         solve_func = SOLVE_FUNCS[a.format]
     except KeyError:
         raise ValueError(f"No suitable solve_functions for {format}")
 
-
-    return solve_func(a._data, b)
-    
+    if np.allclose(a.data, np.tril(a.data)):  # check if lower triangular
+        return solve_func(a.data, b, lower=True)
+    else:  # if upper triangular then standart
+        return solve_func(a.data, b)

--- a/backslash/tests/test_general.py
+++ b/backslash/tests/test_general.py
@@ -2,23 +2,20 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.linalg as sl
 from pytest import raises
-
 from backslash import Array, solve
 
 
 def test_ctor():
     arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=float)
     with raises(TypeError):
-        Array(arr, meaning=42)    
+        Array(arr, meaning=42)
 
 
 def test_formats():
     arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=float)
-    
     # unknown formats raise
     with raises(ValueError):
         Array(arr, format='oops')
-
     # No format is == 'general'
     a1 = Array(arr)
     a2 = Array(arr, format="general")
@@ -33,14 +30,31 @@ def test_format_setter():
         a.format = 'gobbledeegook'
 
 
+
 def test_solve():
-    arr = np.array([[9, 2, 3],
-                    [4, 9, 6],
+    arr = np.array([[9, 0, 0],
+                    [4, 9, 0],
                     [7, 8, 9]], dtype=float)
     b = np.array([1, 1, 1], dtype=float)
-
-    a = Array(arr)
+    a = Array(arr, format="triangular")
     x1 = solve(a, b)
     x2 = sl.solve(arr, b)
+    assert_allclose(x1, x2, atol=1e-14)
 
+    arr = np.array([[6, 8, 7],
+                    [0, 5, 4],
+                    [0, 0, 4]], dtype=float)
+    b = np.array([1, 1, 1], dtype=float)
+    a = Array(arr, format="triangular")
+    x1 = solve(a, b)
+    x2 = sl.solve(arr, b)
+    assert_allclose(x1, x2, atol=1e-14)
+
+    arr = np.array([[1, 0, 0],
+                    [0, 1, 0],
+                    [0, 0, 9]], dtype=float)
+    b = np.array([1, 1, 1], dtype=float)
+    a = Array(arr, format="triangular")
+    x1 = solve(a, b)
+    x2 = sl.solve(arr, b)
     assert_allclose(x1, x2, atol=1e-14)


### PR DESCRIPTION
Истолковал задание так, что известен формат матрицы - triangular. Необходимо определить значение аргумента lower функции solve_triangle.
Посчитал идею дописать функцию normalize_format() так, чтобы она определяла тип матрицы и возвращала формат в зависимости от определенного типа, усложнением. Прошу обозначить, если описанная реализация (с определением типа матрицы) является более приоритетной.
Создал свойство класса Array data(), возвращающий _data, чтобы избежать обращения к приватным методам класса Array (по аналогии с format())